### PR TITLE
Fix iPad landscape browser email view - only middle third shows

### DIFF
--- a/app/email/[id].tsx
+++ b/app/email/[id].tsx
@@ -66,6 +66,20 @@ const EmailDetailScreen = () => {
     setWebViewHeight(windowHeight - 250);
   }, [windowHeight]);
 
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      const updateIframeHeight = () => {
+        const newHeight = Math.max(300, windowHeight - 250);
+        setIframeHeight(newHeight);
+      };
+      
+      updateIframeHeight();
+      
+      window.addEventListener('resize', updateIframeHeight);
+      return () => window.removeEventListener('resize', updateIframeHeight);
+    }
+  }, [windowHeight]);
+
   // Listen for iframe height messages on web
   useEffect(() => {
     if (Platform.OS !== 'web') return;

--- a/utils/email-view-fix.test.ts
+++ b/utils/email-view-fix.test.ts
@@ -39,6 +39,24 @@ describe('Email View Scroll Fix', () => {
     expect(html).toContain('max-width: 100%');
   });
 
+  describe('iframe height calculation', () => {
+    const calculateIframeHeight = (windowHeight: number) => Math.max(300, windowHeight - 250);
+
+    it('uses minimum height of 300 pixels', () => {
+      expect(calculateIframeHeight(200)).toBe(300);
+      expect(calculateIframeHeight(100)).toBe(300);
+    });
+
+    it('calculates height based on window dimensions', () => {
+      expect(calculateIframeHeight(800)).toBe(550);
+      expect(calculateIframeHeight(1000)).toBe(750);
+    });
+
+    it('handles iPad landscape dimensions', () => {
+      expect(calculateIframeHeight(1024)).toBe(774);
+    });
+  });
+
   describe('JavaScript height reporting fix', () => {
     const injectedJs = `
       (function() {


### PR DESCRIPTION
## Summary
- Fixes issue where only middle third of screen shows email content in iPad Safari/Chrome landscape mode
- The iframe height wasn't updating when window dimensions changed (e.g., rotating to landscape)
- Added resize listener to update iframe height on web platform

## Root Cause
- The iframe height was only set once initially and didn't update on window resize
- In landscape mode, the height calculation was incorrect because it didn't account for the new dimensions
- Some emails worked (which had enough content to push the iframe height) while others didn't

## Changes
1. Added useEffect to update iframe height when window dimensions change
2. Added resize event listener for web platform to handle orientation changes
3. Use min height of 300px to prevent too-small iframe

## Tests
Added 3 new tests for iframe height calculation:
- Minimum height of 300 pixels
- Height calculation based on window dimensions  
- iPad landscape dimensions (1024px)

## Fixes Issue #9