### PR TITLE
Add GitHub Actions CI and fix rgb color parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Tests](https://github.com/kimptoc/mygmailexpo/actions/workflows/test.yml/badge.svg)](https://github.com/kimptoc/mygmailexpo/actions/workflows/test.yml)
+
 # Welcome to your Expo app 👋
 
 Its a simple gmail client that lists my emails in my inbox

--- a/hooks/use-tint-contrast.test.ts
+++ b/hooks/use-tint-contrast.test.ts
@@ -1,3 +1,7 @@
+jest.mock('@/hooks/use-theme-color', () => ({
+  useThemeColor: () => '#000000',
+}));
+
 import { isWhiteColor, parseHexColor, parseRgbColor } from './use-tint-contrast';
 
 describe('use-tint-contrast helpers', () => {

--- a/hooks/use-tint-contrast.ts
+++ b/hooks/use-tint-contrast.ts
@@ -36,7 +36,7 @@ export const isWhiteColor = (color: string) => {
     return !!parsed && parsed.r === 255 && parsed.g === 255 && parsed.b === 255 && parsed.a !== 0;
   }
   if (normalized.startsWith('rgb(') || normalized.startsWith('rgba(')) {
-    const inner = normalized.replace(/rgba?\\(|\\)/g, '');
+    const inner = normalized.replace(/rgba?\(|\)/g, '');
     const parsed = parseRgbColor(inner);
     return !!parsed && parsed.r === 255 && parsed.g === 255 && parsed.b === 255 && parsed.a !== 0;
   }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to run tests on push/PR to main
- Add test status badge to README
- Fix double-escaped regex in `isWhiteColor()` that broke `rgb()`/`rgba()` parsing
- Add `use-theme-color` mock to tint contrast test for Node environment compatibility

## Test plan
- [ ] Verify GitHub Actions workflow runs and passes (10 suites, 56 tests)
- [ ] Verify badge renders correctly in README on GitHub
- [ ] Confirm `isWhiteColor('rgb(255, 255, 255)')` now returns `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)