### PR TITLE
Fix undo toast disappearing quickly on consecutive actions

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -51,7 +51,7 @@ export function Toast({ message, type = 'info', visible, onHide, undoAction, onU
         animationRef.current.stop();
       }
     };
-  }, [visible, onHide, opacity, hasUndo]);
+  }, [visible, message, onHide, opacity, hasUndo]);
 
   if (!visible) return null;
 


### PR DESCRIPTION
## Summary
- Fixes the undo popup disappearing almost instantly when removing a label from a single item after previously removing from several items
- Root cause: Toast animation `useEffect` didn't re-trigger when a new toast replaced the current one because `visible` stayed `true` and no other deps changed
- Fix: Added `message` to the dependency array so the animation restarts when toast content changes

Fixes #12

## Test plan
- [ ] Remove labels from multiple emails (batch) — verify undo toast appears for ~10 seconds
- [ ] Immediately after, remove a label from a single email — verify the new undo toast also stays visible for ~10 seconds
- [ ] Verify normal (non-undo) toasts still auto-dismiss after 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)