### PR TITLE
Add archive action for INBOX in selection mode and email detail

### DIFF
--- a/app/email/[id].tsx
+++ b/app/email/[id].tsx
@@ -24,6 +24,7 @@ import FolderSelectionModal from '@/components/FolderSelectionModal';
 import { useToast } from '@/contexts/ToastContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActionButtonColors } from '@/hooks/use-tint-contrast';
+import { getSelectionAction } from '@/utils/folder-actions';
 
 const EmailDetailScreen = () => {
   const { id, folderId } = useLocalSearchParams<{ id: string; folderId?: string }>();
@@ -119,26 +120,26 @@ const EmailDetailScreen = () => {
     }
   };
 
-  const handleRemoveLabel = async () => {
-    if (!folderId) return;
+  const handleArchiveOrRemove = async () => {
     setActionLoading(true);
-    const removedLabelId = folderId;
+    const sourceFolderId = folderId ?? 'INBOX';
+    const isArchive = sourceFolderId === 'INBOX';
     try {
-      await removeLabelFromEmails([id], removedLabelId);
+      await removeLabelFromEmails([id], sourceFolderId);
       showUndoToast(
-        '1 email removed',
+        isArchive ? '1 email archived' : '1 email removed',
         {
           id: `remove-label-${id}-${Date.now()}`,
           label: 'Undo',
           undo: async () => {
-            await addLabelsToEmails([id], [removedLabelId]);
+            await addLabelsToEmails([id], [sourceFolderId]);
           }
         }
       );
       router.back();
     } catch (err: any) {
       console.error('Error removing label:', err);
-      showToast(err.message || 'Failed to remove label', 'error');
+      showToast(err.message || (isArchive ? 'Failed to archive email' : 'Failed to remove label'), 'error');
       setActionLoading(false);
     }
   };
@@ -168,15 +169,10 @@ const EmailDetailScreen = () => {
     }
   };
 
-  // Check if we should show Remove Label button
-  // Show if we are in a custom user label (not INBOX/System/Category)
-  const showRemoveLabel = useMemo(() => {
-    if (!folderId) return false;
-    if (folderId === 'INBOX') return false;
-    if (folderId.startsWith('CATEGORY_')) return false;
-    if (['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD'].includes(folderId)) return false;
-    return true;
-  }, [folderId]);
+  const selectionAction = useMemo(
+    () => getSelectionAction(folderId ?? 'INBOX'),
+    [folderId]
+  );
 
   const folderName = useMemo(() => {
     if (!folderId) return '';
@@ -419,9 +415,19 @@ const EmailDetailScreen = () => {
             <ActivityIndicator color={textColor} style={{ marginRight: 16 }} />
           ) : (
             <>
-              {showRemoveLabel && (
-                <TouchableOpacity 
-                  onPress={handleRemoveLabel} 
+              {selectionAction === 'archive' && (
+                <TouchableOpacity
+                  onPress={handleArchiveOrRemove}
+                  style={[styles.actionButton, styles.actionHitSlop]}
+                  accessibilityLabel="Archive"
+                  {...{ title: "Archive" } as any}
+                >
+                  <IconSymbol name="archivebox" size={isLargeScreen ? 28 : 22} color={textColor} />
+                </TouchableOpacity>
+              )}
+              {selectionAction === 'remove-label' && (
+                <TouchableOpacity
+                  onPress={handleArchiveOrRemove}
                   style={[styles.actionButton, styles.actionHitSlop]}
                   accessibilityLabel="Remove label"
                   {...{ title: "Remove label" } as any}
@@ -429,8 +435,8 @@ const EmailDetailScreen = () => {
                   <IconSymbol name="tag.slash" size={isLargeScreen ? 28 : 22} color={textColor} />
                 </TouchableOpacity>
               )}
-              <TouchableOpacity 
-                onPress={() => setShowFolderModal(true)} 
+              <TouchableOpacity
+                onPress={() => setShowFolderModal(true)}
                 style={[styles.actionButton, styles.actionHitSlop]}
                 accessibilityLabel="Move to folder"
                 {...{ title: "Move to folder" } as any}

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -353,8 +353,7 @@ export function InboxScreen() {
     }
   }, [isSelectionMode, loadEmails, handleMoveToFolder]);
 
-  const sourceFolderId = currentFolder?.id ?? 'INBOX';
-  const selectionAction = getSelectionAction(sourceFolderId);
+  const selectionAction = getSelectionAction(currentFolder?.id ?? 'INBOX');
 
   const renderEmail = useCallback(
     ({ item }: { item: Email }) => (

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -486,7 +486,7 @@ export function InboxScreen() {
                   <TouchableOpacity
                     onPress={() => setShowFolderModal(true)}
                     style={styles.selectionActionButton}
-                    accessibilityLabel="Move"
+                    accessibilityLabel="Move to folder"
                   >
                     <IconSymbol name="folder" size={iconSize} color={selectionHeaderText} />
                   </TouchableOpacity>

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -28,6 +28,7 @@ import ComposeEmailModal from '@/components/ComposeEmailModal';
 import { useActionButtonColors } from '@/hooks/use-tint-contrast';
 
 import { useEmailSelection } from '@/hooks/useEmailSelection';
+import { getSelectionAction } from '@/utils/folder-actions';
 
 import { EmailItemSkeleton } from '@/components/EmailItemSkeleton';
 
@@ -210,10 +211,9 @@ export function InboxScreen() {
   }, [emailState.emails, selectedIds.size, selectAll, clearSelection]);
 
   const handleRemoveLabelBatch = useCallback(async (idsToProcess?: string[]) => {
-    if (!currentFolder) return;
     setActionLoading(true);
     const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
-    const sourceFolderId = currentFolder.id;
+    const sourceFolderId = currentFolder?.id ?? 'INBOX';
     setBatchProgress({
       processed: 0,
       total: ids.length,
@@ -236,8 +236,11 @@ export function InboxScreen() {
         setShowErrorModal(true);
       } else {
         const count = result.succeeded.length;
+        const message = sourceFolderId === 'INBOX'
+          ? `${count} email(s) archived`
+          : `${count} email(s) removed`;
         showUndoToast(
-          `${count} email(s) removed`,
+          message,
           {
             id: `remove-label-batch-${Date.now()}`,
             label: 'Undo',
@@ -350,10 +353,8 @@ export function InboxScreen() {
     }
   }, [isSelectionMode, loadEmails, handleMoveToFolder]);
 
-  const showRemoveLabel = !!currentFolder && 
-    currentFolder.id !== 'INBOX' && 
-    !currentFolder.id.startsWith('CATEGORY_') && 
-    !['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD'].includes(currentFolder.id);
+  const sourceFolderId = currentFolder?.id ?? 'INBOX';
+  const selectionAction = getSelectionAction(sourceFolderId);
 
   const renderEmail = useCallback(
     ({ item }: { item: Email }) => (
@@ -465,12 +466,29 @@ export function InboxScreen() {
                 <ActivityIndicator color={selectionHeaderText} style={{ marginRight: 16 }} />
               ) : (
                 <>
-                  {showRemoveLabel && (
-                    <TouchableOpacity onPress={handleRemoveLabelBatch} style={styles.selectionActionButton}>
+                  {selectionAction === 'archive' && (
+                    <TouchableOpacity
+                      onPress={() => handleRemoveLabelBatch()}
+                      style={styles.selectionActionButton}
+                      accessibilityLabel="Archive"
+                    >
+                      <IconSymbol name="archivebox" size={iconSize} color={selectionHeaderText} />
+                    </TouchableOpacity>
+                  )}
+                  {selectionAction === 'remove-label' && (
+                    <TouchableOpacity
+                      onPress={() => handleRemoveLabelBatch()}
+                      style={styles.selectionActionButton}
+                      accessibilityLabel="Remove label"
+                    >
                       <IconSymbol name="tag.slash" size={iconSize} color={selectionHeaderText} />
                     </TouchableOpacity>
                   )}
-                  <TouchableOpacity onPress={() => setShowFolderModal(true)} style={styles.selectionActionButton}>
+                  <TouchableOpacity
+                    onPress={() => setShowFolderModal(true)}
+                    style={styles.selectionActionButton}
+                    accessibilityLabel="Move"
+                  >
                     <IconSymbol name="folder" size={iconSize} color={selectionHeaderText} />
                   </TouchableOpacity>
                 </>

--- a/docs/superpowers/plans/2026-05-01-archive-email-detail.md
+++ b/docs/superpowers/plans/2026-05-01-archive-email-detail.md
@@ -1,0 +1,274 @@
+# Email-Detail Archive Button — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show an Archive button on the email-detail header when the email was opened from INBOX, alongside the existing Move button. Mirrors the selection-mode treatment already shipped in `components/InboxScreen.tsx`.
+
+**Architecture:** Reuse the existing pure utility `getSelectionAction(folderId)` from `utils/folder-actions.ts`. Replace the boolean `showRemoveLabel` `useMemo` in `app/email/[id].tsx` with a `selectionAction` `useMemo` returning `'archive' | 'remove-label' | 'none'`. Rename `handleRemoveLabel` to `handleArchiveOrRemove`, drop its INBOX-blocking guard, and branch the success-toast wording.
+
+**Tech Stack:** TypeScript, React Native, Expo Router, Jest + ts-jest (Node test env).
+
+**Spec:** `docs/superpowers/specs/2026-05-01-archive-email-detail-design.md`
+
+---
+
+## File structure
+
+- **Modify:** `app/email/[id].tsx` — single file, four touch-points (import, `useMemo`, handler, JSX).
+
+No new files, no new tests (the underlying utility is already covered by `utils/folder-actions.test.ts`).
+
+---
+
+## Task 1: Wire archive action into email-detail header
+
+**Files:**
+- Modify: `app/email/[id].tsx` (import, derived value, handler rename + tweak, JSX render)
+
+**Background:** Today the file has a `useMemo`-derived boolean `showRemoveLabel` (lines 173-179) with the same exclusion logic that the inbox screen used to have. The handler `handleRemoveLabel` (lines 122-144) early-returns when `folderId` is missing and only knows the "remove label" wording. The header JSX (lines 422-431) renders a single conditional Remove-label button. After this task, the screen handles INBOX as a valid source the same way `InboxScreen.tsx` already does.
+
+- [ ] **Step 1: Add the import**
+
+In `app/email/[id].tsx`, add this import near the other `@/` imports at the top of the file (the existing imports are alphabetically loose; placing it after the `useActionButtonColors` import keeps it near the other utility-style imports):
+
+```ts
+import { getSelectionAction } from '@/utils/folder-actions';
+```
+
+- [ ] **Step 2: Replace the visibility derivation**
+
+Locate this block (around lines 173-179):
+
+```ts
+// Check if we should show Remove Label button
+// Show if we are in a custom user label (not INBOX/System/Category)
+const showRemoveLabel = useMemo(() => {
+  if (!folderId) return false;
+  if (folderId === 'INBOX') return false;
+  if (folderId.startsWith('CATEGORY_')) return false;
+  if (['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD'].includes(folderId)) return false;
+  return true;
+}, [folderId]);
+```
+
+Replace with:
+
+```ts
+const selectionAction = useMemo(
+  () => getSelectionAction(folderId ?? 'INBOX'),
+  [folderId]
+);
+```
+
+(Drop the comment block — the function name now says what was being checked.)
+
+- [ ] **Step 3: Rename and update the action handler**
+
+Locate `handleRemoveLabel` (around lines 122-144):
+
+```ts
+const handleRemoveLabel = async () => {
+  if (!folderId) return;
+  setActionLoading(true);
+  const removedLabelId = folderId;
+  try {
+    await removeLabelFromEmails([id], removedLabelId);
+    showUndoToast(
+      '1 email removed',
+      {
+        id: `remove-label-${id}-${Date.now()}`,
+        label: 'Undo',
+        undo: async () => {
+          await addLabelsToEmails([id], [removedLabelId]);
+        }
+      }
+    );
+    router.back();
+  } catch (err: any) {
+    console.error('Error removing label:', err);
+    showToast(err.message || 'Failed to remove label', 'error');
+    setActionLoading(false);
+  }
+};
+```
+
+Replace with:
+
+```ts
+const handleArchiveOrRemove = async () => {
+  setActionLoading(true);
+  const sourceFolderId = folderId ?? 'INBOX';
+  const isArchive = sourceFolderId === 'INBOX';
+  try {
+    await removeLabelFromEmails([id], sourceFolderId);
+    showUndoToast(
+      isArchive ? '1 email archived' : '1 email removed',
+      {
+        id: `remove-label-${id}-${Date.now()}`,
+        label: 'Undo',
+        undo: async () => {
+          await addLabelsToEmails([id], [sourceFolderId]);
+        }
+      }
+    );
+    router.back();
+  } catch (err: any) {
+    console.error('Error removing label:', err);
+    showToast(err.message || (isArchive ? 'Failed to archive email' : 'Failed to remove label'), 'error');
+    setActionLoading(false);
+  }
+};
+```
+
+Changes summary:
+- Function name: `handleRemoveLabel` → `handleArchiveOrRemove`.
+- Removed the `if (!folderId) return;` guard.
+- Renamed local `removedLabelId` → `sourceFolderId`, with `?? 'INBOX'` fallback.
+- Toast wording branches on `isArchive`.
+- Error toast wording branches on `isArchive` so the user sees `"Failed to archive email"` instead of `"Failed to remove label"` when archiving (only used when the API didn't supply a message).
+
+- [ ] **Step 4: Update the button render**
+
+Locate the header action block (around lines 421-440 — the inner content of the `<>` fragment that runs when `actionLoading` is false):
+
+```tsx
+<>
+  {showRemoveLabel && (
+    <TouchableOpacity 
+      onPress={handleRemoveLabel} 
+      style={[styles.actionButton, styles.actionHitSlop]}
+      accessibilityLabel="Remove label"
+      {...{ title: "Remove label" } as any}
+    >
+      <IconSymbol name="tag.slash" size={isLargeScreen ? 28 : 22} color={textColor} />
+    </TouchableOpacity>
+  )}
+  <TouchableOpacity 
+    onPress={() => setShowFolderModal(true)} 
+    style={[styles.actionButton, styles.actionHitSlop]}
+    accessibilityLabel="Move to folder"
+    {...{ title: "Move to folder" } as any}
+  >
+    <IconSymbol name="folder" size={isLargeScreen ? 28 : 22} color={textColor} />
+  </TouchableOpacity>
+</>
+```
+
+Replace with:
+
+```tsx
+<>
+  {selectionAction === 'archive' && (
+    <TouchableOpacity 
+      onPress={handleArchiveOrRemove} 
+      style={[styles.actionButton, styles.actionHitSlop]}
+      accessibilityLabel="Archive"
+      {...{ title: "Archive" } as any}
+    >
+      <IconSymbol name="archivebox" size={isLargeScreen ? 28 : 22} color={textColor} />
+    </TouchableOpacity>
+  )}
+  {selectionAction === 'remove-label' && (
+    <TouchableOpacity 
+      onPress={handleArchiveOrRemove} 
+      style={[styles.actionButton, styles.actionHitSlop]}
+      accessibilityLabel="Remove label"
+      {...{ title: "Remove label" } as any}
+    >
+      <IconSymbol name="tag.slash" size={isLargeScreen ? 28 : 22} color={textColor} />
+    </TouchableOpacity>
+  )}
+  <TouchableOpacity 
+    onPress={() => setShowFolderModal(true)} 
+    style={[styles.actionButton, styles.actionHitSlop]}
+    accessibilityLabel="Move to folder"
+    {...{ title: "Move to folder" } as any}
+  >
+    <IconSymbol name="folder" size={isLargeScreen ? 28 : 22} color={textColor} />
+  </TouchableOpacity>
+</>
+```
+
+Changes summary:
+- The single `showRemoveLabel`-gated button becomes two mutually-exclusive blocks (archive | remove-label).
+- Both call the renamed `handleArchiveOrRemove`.
+- The Move button is unchanged.
+- `selectionAction === 'none'` renders nothing — same as today's `showRemoveLabel = false` behaviour.
+
+- [ ] **Step 5: Run the existing test suite to confirm nothing regressed**
+
+Run: `npm test`
+Expected: PASS — all existing tests (60 at last count, including `folder-actions.test.ts`).
+
+- [ ] **Step 6: TypeScript check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Lint**
+
+Run: `npm run lint`
+Expected: no new errors introduced by these edits (pre-existing warnings are acceptable).
+
+- [ ] **Step 8: Verify there are no stale references**
+
+Run: `git grep -n 'showRemoveLabel\|handleRemoveLabel' app/email/`
+Expected: no output (both old identifiers should be gone from the email-detail directory).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/email/\[id\].tsx
+git commit -m "Add archive action to email detail when opened from INBOX"
+```
+
+(The square brackets in the path must be escaped for the shell; alternatively quote the path: `git add 'app/email/[id].tsx'`.)
+
+---
+
+## Task 2: Manual verification
+
+**Files:** none — this is on-device testing.
+
+**Background:** The email-detail screen has no existing component tests, and adding RN component tests purely for this two-button rendering would be over-investment. Verify per the spec's manual testing checklist.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npx expo start`
+
+- [ ] **Step 2: Verify INBOX archive happy path**
+
+In the running app:
+1. From the inbox list, tap an email to open the detail screen.
+2. Confirm the header shows two action icons: archive (`archivebox`) then folder.
+3. Tap archive.
+4. Confirm: navigation returns to the inbox list, the archived email is no longer in the list, toast reads `"1 email archived"` with an Undo action.
+5. Tap Undo. Confirm: the email returns to the inbox list.
+
+- [ ] **Step 3: Verify user-label flow unchanged**
+
+Switch to a user label, tap an email to open detail. Confirm the header shows `tag.slash` then folder, the toast on tap still reads `"1 email removed"`, and Undo works.
+
+- [ ] **Step 4: Verify system-label views**
+
+Open an email from STARRED (or SENT, TRASH). Confirm only the Move button renders — no archive, no remove-label.
+
+- [ ] **Step 5: Verify Move flow still works in INBOX**
+
+Back in INBOX, open an email, tap the folder button. Confirm the folder selection modal opens and moving works as before.
+
+- [ ] **Step 6: Verify error path**
+
+With network disabled (or a Gmail API failure simulated), open an email from INBOX and tap archive. Confirm: an error toast appears (default text `"Failed to archive email"` if the API didn't supply a specific message), and the header buttons re-appear after the spinner clears.
+
+- [ ] **Step 7: Sign off**
+
+If all the above pass, the feature is complete. If any step fails, file the failure as a follow-up and do not mark the task done.
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** Visibility derivation (Task 1.2), handler rename + INBOX guard removal (Task 1.3), toast wording branch (Task 1.3), button render (Task 1.4), error-handling preservation (Task 1.3 — try/catch unchanged), manual checklist (Task 2). All spec sections mapped.
+- **Placeholder scan:** No TBDs, every code step has a complete code block.
+- **Type consistency:** `getSelectionAction` import path matches the file created in the previous feature (`@/utils/folder-actions`); `selectionAction` value `'archive' | 'remove-label' | 'none'` is checked exhaustively in JSX (the third value renders nothing); `handleArchiveOrRemove` is referenced consistently in the renamed handler and both `onPress` sites.

--- a/docs/superpowers/plans/2026-05-01-archive-inbox-button.md
+++ b/docs/superpowers/plans/2026-05-01-archive-inbox-button.md
@@ -1,0 +1,315 @@
+# Archive Button for INBOX Selection Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Archive action to selection mode when viewing INBOX, alongside the existing Move action. Archive removes the `INBOX` label from selected emails (Gmail's archive semantics).
+
+**Architecture:** Extract folder-action eligibility into a pure utility (`utils/folder-actions.ts`) covered by unit tests. Wire it into `components/InboxScreen.tsx` so the selection-mode header renders an archive icon when the source folder is INBOX, a remove-label icon for user labels, and nothing for system labels. Reuse the existing `removeLabelFromEmails` API call — Gmail's archive *is* `removeLabelIds: ['INBOX']`.
+
+**Tech Stack:** TypeScript, React Native, Expo Router, Jest + ts-jest (Node test env).
+
+**Spec:** `docs/superpowers/specs/2026-05-01-archive-inbox-button-design.md`
+
+---
+
+## File structure
+
+- **Create:** `utils/folder-actions.ts` — pure function `getSelectionAction(folderId)` returning `'archive' | 'remove-label' | 'none'`.
+- **Create:** `utils/folder-actions.test.ts` — Jest unit tests for the predicate.
+- **Modify:** `components/InboxScreen.tsx` — import the util, replace `showRemoveLabel` derivation, render the right icon, branch toast wording, allow `handleRemoveLabelBatch` to run when source is INBOX.
+
+No other files change.
+
+---
+
+## Task 1: Pure utility for selection-mode action eligibility
+
+**Files:**
+- Create: `utils/folder-actions.ts`
+- Test: `utils/folder-actions.test.ts`
+
+**Background:** Today, `InboxScreen.tsx:353-356` derives `showRemoveLabel` inline. We need INBOX → archive, user labels → remove-label, system labels (TRASH, SENT, DRAFTS, SPAM, STARRED, IMPORTANT, UNREAD, anything starting `CATEGORY_`) → no action button. Encode this once, test it once.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `utils/folder-actions.test.ts`:
+
+```ts
+import { getSelectionAction } from './folder-actions';
+
+describe('getSelectionAction', () => {
+  it('returns "archive" for INBOX', () => {
+    expect(getSelectionAction('INBOX')).toBe('archive');
+  });
+
+  it('returns "remove-label" for a user label id', () => {
+    expect(getSelectionAction('Label_123')).toBe('remove-label');
+    expect(getSelectionAction('Label_abc')).toBe('remove-label');
+  });
+
+  it('returns "none" for Gmail system pseudo-labels', () => {
+    for (const id of ['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD']) {
+      expect(getSelectionAction(id)).toBe('none');
+    }
+  });
+
+  it('returns "none" for CATEGORY_* labels', () => {
+    expect(getSelectionAction('CATEGORY_PROMOTIONS')).toBe('none');
+    expect(getSelectionAction('CATEGORY_SOCIAL')).toBe('none');
+    expect(getSelectionAction('CATEGORY_UPDATES')).toBe('none');
+    expect(getSelectionAction('CATEGORY_FORUMS')).toBe('none');
+    expect(getSelectionAction('CATEGORY_PERSONAL')).toBe('none');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- utils/folder-actions.test.ts`
+Expected: FAIL with module-not-found error for `./folder-actions`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `utils/folder-actions.ts`:
+
+```ts
+export type SelectionAction = 'archive' | 'remove-label' | 'none';
+
+const SYSTEM_LABEL_IDS = new Set([
+  'TRASH',
+  'SENT',
+  'DRAFTS',
+  'SPAM',
+  'STARRED',
+  'IMPORTANT',
+  'UNREAD',
+]);
+
+export function getSelectionAction(folderId: string): SelectionAction {
+  if (folderId === 'INBOX') return 'archive';
+  if (folderId.startsWith('CATEGORY_')) return 'none';
+  if (SYSTEM_LABEL_IDS.has(folderId)) return 'none';
+  return 'remove-label';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- utils/folder-actions.test.ts`
+Expected: PASS — all four `it` blocks green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/folder-actions.ts utils/folder-actions.test.ts
+git commit -m "Add getSelectionAction utility for folder action eligibility"
+```
+
+---
+
+## Task 2: Wire archive action into InboxScreen
+
+**Files:**
+- Modify: `components/InboxScreen.tsx` (import, derived value, button render, handler tweak)
+
+**Background:** `handleRemoveLabelBatch` (`InboxScreen.tsx:212-266`) currently early-returns when `currentFolder` is null. The button visibility at `InboxScreen.tsx:353-356` requires `currentFolder` to be set. Both need to allow INBOX as a source. The button render at `InboxScreen.tsx:468-472` needs to switch icon/label based on the action.
+
+- [ ] **Step 1: Add the import**
+
+Add this import near the other `@/` imports at the top of `components/InboxScreen.tsx` (alphabetical fits after the `useEmailSelection` import block):
+
+```ts
+import { getSelectionAction } from '@/utils/folder-actions';
+```
+
+- [ ] **Step 2: Replace the visibility derivation**
+
+In `components/InboxScreen.tsx`, locate this block (around line 353-356):
+
+```ts
+const showRemoveLabel = !!currentFolder && 
+  currentFolder.id !== 'INBOX' && 
+  !currentFolder.id.startsWith('CATEGORY_') && 
+  !['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD'].includes(currentFolder.id);
+```
+
+Replace with:
+
+```ts
+const sourceFolderId = currentFolder?.id ?? 'INBOX';
+const selectionAction = getSelectionAction(sourceFolderId);
+```
+
+- [ ] **Step 3: Update `handleRemoveLabelBatch` to allow INBOX**
+
+In `components/InboxScreen.tsx`, locate `handleRemoveLabelBatch` (starts around line 212). Replace the body up to the `try` block. The current code starts:
+
+```ts
+const handleRemoveLabelBatch = useCallback(async (idsToProcess?: string[]) => {
+  if (!currentFolder) return;
+  setActionLoading(true);
+  const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
+  const sourceFolderId = currentFolder.id;
+```
+
+Change to:
+
+```ts
+const handleRemoveLabelBatch = useCallback(async (idsToProcess?: string[]) => {
+  setActionLoading(true);
+  const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
+  const sourceFolderId = currentFolder?.id ?? 'INBOX';
+```
+
+(Remove the `if (!currentFolder) return;` line; change the const initializer from `currentFolder.id` to `currentFolder?.id ?? 'INBOX'`.)
+
+- [ ] **Step 4: Branch the success-toast wording**
+
+Still in `handleRemoveLabelBatch`, locate the success branch (around line 238-254 in the pre-edit file):
+
+```ts
+} else {
+  const count = result.succeeded.length;
+  showUndoToast(
+    `${count} email(s) removed`,
+    {
+      id: `remove-label-batch-${Date.now()}`,
+```
+
+Replace with:
+
+```ts
+} else {
+  const count = result.succeeded.length;
+  const message = sourceFolderId === 'INBOX'
+    ? `${count} email(s) archived`
+    : `${count} email(s) removed`;
+  showUndoToast(
+    message,
+    {
+      id: `remove-label-batch-${Date.now()}`,
+```
+
+The rest of the success branch (the `undo` callback that calls `addLabelsToEmails(ids, [sourceFolderId])`) is unchanged — re-adding INBOX is exactly unarchive.
+
+- [ ] **Step 5: Update the button render**
+
+In `components/InboxScreen.tsx`, locate the selection-mode header render block (around line 467-475):
+
+```tsx
+<>
+  {showRemoveLabel && (
+    <TouchableOpacity onPress={handleRemoveLabelBatch} style={styles.selectionActionButton}>
+      <IconSymbol name="tag.slash" size={iconSize} color={selectionHeaderText} />
+    </TouchableOpacity>
+  )}
+  <TouchableOpacity onPress={() => setShowFolderModal(true)} style={styles.selectionActionButton}>
+    <IconSymbol name="folder" size={iconSize} color={selectionHeaderText} />
+  </TouchableOpacity>
+</>
+```
+
+Replace with:
+
+```tsx
+<>
+  {selectionAction === 'archive' && (
+    <TouchableOpacity
+      onPress={() => handleRemoveLabelBatch()}
+      style={styles.selectionActionButton}
+      accessibilityLabel="Archive"
+    >
+      <IconSymbol name="archivebox" size={iconSize} color={selectionHeaderText} />
+    </TouchableOpacity>
+  )}
+  {selectionAction === 'remove-label' && (
+    <TouchableOpacity
+      onPress={() => handleRemoveLabelBatch()}
+      style={styles.selectionActionButton}
+      accessibilityLabel="Remove label"
+    >
+      <IconSymbol name="tag.slash" size={iconSize} color={selectionHeaderText} />
+    </TouchableOpacity>
+  )}
+  <TouchableOpacity
+    onPress={() => setShowFolderModal(true)}
+    style={styles.selectionActionButton}
+    accessibilityLabel="Move"
+  >
+    <IconSymbol name="folder" size={iconSize} color={selectionHeaderText} />
+  </TouchableOpacity>
+</>
+```
+
+(Wrap `handleRemoveLabelBatch` in an arrow function so the `TouchableOpacity` `onPress` event object isn't passed as `idsToProcess`. The third button — Move — gains an `accessibilityLabel` for consistency.)
+
+- [ ] **Step 6: Run the existing test suite to confirm nothing regressed**
+
+Run: `npm test`
+Expected: PASS — all existing tests plus the new `folder-actions.test.ts` pass.
+
+- [ ] **Step 7: TypeScript check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Lint**
+
+Run: `npm run lint`
+Expected: no new errors introduced by these edits.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add components/InboxScreen.tsx
+git commit -m "Add archive action to INBOX selection mode"
+```
+
+---
+
+## Task 3: Manual verification
+
+**Files:** none — this is on-device testing.
+
+**Background:** The view-layer changes can't be unit-tested without a React Native test renderer, which the project doesn't currently use for screens. Verify per the spec's testing checklist.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npx expo start`
+
+- [ ] **Step 2: Verify INBOX archive happy path**
+
+In the running app, in INBOX:
+1. Long-press an email to enter selection mode.
+2. Confirm two icon buttons render in the header: archive (`archivebox`) then folder.
+3. Tap the archive button.
+4. Confirm: selected email disappears from the list; toast reads `"1 email(s) archived"` with an Undo action.
+5. Tap Undo. Confirm: the email returns to the inbox list.
+
+- [ ] **Step 3: Verify multi-select archive**
+
+In INBOX, select 3 emails, tap archive. Confirm toast reads `"3 email(s) archived"`, all three disappear, Undo restores all three.
+
+- [ ] **Step 4: Verify user-label flow unchanged**
+
+Switch to a user label (e.g., a personal label). Long-press, select. Confirm the layout shows the `tag.slash` icon then folder, the toast on remove still reads `"N email(s) removed"`, and Undo works.
+
+- [ ] **Step 5: Verify system-label views**
+
+Switch to STARRED (or SENT). Enter selection mode. Confirm only the Move (folder) button renders — no archive, no remove-label.
+
+- [ ] **Step 6: Verify Move flow still works in INBOX**
+
+Back in INBOX, select an email, tap the folder button. Confirm the folder selection modal opens and moving works as before.
+
+- [ ] **Step 7: Sign off**
+
+If all the above pass, the feature is complete. If any step fails, file the failure as a follow-up and do not mark the task done.
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** Visibility predicate (Task 1), button render (Task 2.5), handler tweak (Task 2.3), toast wording (Task 2.4), error-modal pass-through (no change needed — covered in spec rationale), manual test checklist (Task 3) — all spec sections mapped.
+- **Placeholder scan:** No TBDs, no "implement later", every code step has a complete code block.
+- **Type consistency:** `getSelectionAction` signature matches both call sites (`utils/folder-actions.ts` definition and `InboxScreen.tsx` import); `selectionAction` value `'archive' | 'remove-label' | 'none'` is checked exhaustively in the render branch.

--- a/docs/superpowers/specs/2026-05-01-archive-email-detail-design.md
+++ b/docs/superpowers/specs/2026-05-01-archive-email-detail-design.md
@@ -1,0 +1,95 @@
+# Archive Button on Email Detail Screen
+
+**Date:** 2026-05-01
+**Status:** Draft
+**Scope:** Single-file UI change in `app/email/[id].tsx`
+
+## Problem
+
+When viewing a single email opened from a user label, the email-detail header shows a **Remove label** button (`tag.slash`) alongside the **Move** button. When viewing an email opened from INBOX, the Remove-label button is hidden, so the only one-tap option is Move. There is no quick way to archive a single email from the detail screen.
+
+This mirrors the gap that was just closed in selection mode (`components/InboxScreen.tsx`) by adding an Archive action when the source folder is INBOX. The detail screen needs the same treatment so the two surfaces stay consistent.
+
+## Goal
+
+In the email-detail header, when the email was opened from INBOX, render an **Archive** button. When opened from a user label, keep the existing **Remove label** button. Move button is unchanged on every view.
+
+## Non-goals
+
+- No changes to label chips, sender row, body rendering, or the WebView.
+- No new API surface in `services/gmailApi.ts` — archive *is* `removeLabelIds: ['INBOX']` and the existing `removeLabelFromEmails` already handles it.
+- No changes to selection-mode in `InboxScreen.tsx` (already done in the prior spec).
+- No changes to inbox/label list rendering.
+
+## Design
+
+### Reuse the existing utility
+
+`utils/folder-actions.ts` already exports `getSelectionAction(folderId)` returning `'archive' | 'remove-label' | 'none'` and is unit-tested. The detail screen consumes it directly — no new utility is needed.
+
+### Visibility
+
+Replace the current `useMemo`-derived `showRemoveLabel` (`app/email/[id].tsx:173-179`) with:
+
+```ts
+const selectionAction = useMemo(
+  () => getSelectionAction(folderId ?? 'INBOX'),
+  [folderId]
+);
+```
+
+Same memoization profile, same dependency on `folderId`. The triple result (`'archive' | 'remove-label' | 'none'`) replaces the boolean.
+
+### Handler
+
+`handleRemoveLabel` (`app/email/[id].tsx:122-144`) is renamed to `handleArchiveOrRemove` to reflect its new dual purpose.
+
+Body changes:
+
+1. Drop the `if (!folderId) return;` early-return guard.
+2. Replace `const removedLabelId = folderId;` with `const sourceFolderId = folderId ?? 'INBOX';` — the value driving both the API call and the toast wording.
+3. Branch the toast text: `sourceFolderId === 'INBOX'` → `"1 email archived"`, otherwise the existing `"1 email removed"`.
+4. The `removeLabelFromEmails([id], sourceFolderId)` call uses the new `sourceFolderId`. The undo callback (`addLabelsToEmails([id], [sourceFolderId])`) is unchanged in behaviour — adding INBOX back is exactly unarchive.
+5. `router.back()` and error handling stay as-is.
+
+### Button render
+
+In the header action block (`app/email/[id].tsx:422-431`), replace the single conditional Remove-label `<TouchableOpacity>` with two mutually-exclusive blocks:
+
+- `selectionAction === 'archive'` → render `<TouchableOpacity onPress={handleArchiveOrRemove}>` with `IconSymbol name="archivebox"` and `accessibilityLabel="Archive"`.
+- `selectionAction === 'remove-label'` → render the same component with `IconSymbol name="tag.slash"` and `accessibilityLabel="Remove label"`.
+- `selectionAction === 'none'` → render nothing (today's behavior for system-label-sourced emails is unchanged).
+
+The Move button is always rendered after these, unchanged.
+
+### Error handling
+
+`handleArchiveOrRemove` retains the existing try/catch. Failure paths show the same error toast and reset `actionLoading` — no behavior change for failures.
+
+## Consistency with `InboxScreen.tsx`
+
+The selection-mode wire-up in `components/InboxScreen.tsx` already uses `getSelectionAction` and the same `archivebox` / `tag.slash` icon pair with the same accessibility labels. After this change, the two surfaces present consistent affordances.
+
+## Out of scope / future considerations
+
+- A confirmation prompt before archiving. Not needed: undo is provided via the toast, mirroring the existing remove-label flow.
+- Archive from list-item swipe gestures or quick actions. Not in scope.
+- Bulk-archive surfaces beyond the existing selection mode. Not in scope.
+
+## Testing
+
+No new unit tests required — `getSelectionAction` is already covered by `utils/folder-actions.test.ts`. The detail screen has no existing component tests to extend.
+
+Manual verification:
+
+1. Open an email from INBOX. Confirm the header shows `[Archive][Move]` (in that order). Tap archive. Confirm: navigation returns to the inbox list, the email is gone from the list, toast reads `"1 email archived"` with Undo.
+2. Tap Undo. Confirm: the email returns to the inbox list.
+3. Open an email from a user label. Confirm the header still shows `[Remove label][Move]` and the toast on remove still reads `"1 email removed"`.
+4. Open an email from a system folder (STARRED, SENT, TRASH, etc.). Confirm only the Move button renders.
+5. With network disabled, attempt archive. Confirm the error toast appears and `actionLoading` clears (header buttons re-appear).
+
+## Files touched
+
+- `app/email/[id].tsx` — visibility derivation, handler rename + tweak, button render.
+
+No other files modified.

--- a/docs/superpowers/specs/2026-05-01-archive-inbox-button-design.md
+++ b/docs/superpowers/specs/2026-05-01-archive-inbox-button-design.md
@@ -1,0 +1,89 @@
+# Archive Button for INBOX Selection Mode
+
+**Date:** 2026-05-01
+**Status:** Draft
+**Scope:** Single-file UI change in `components/InboxScreen.tsx`
+
+## Problem
+
+When viewing a user label and entering selection mode, two action buttons are shown:
+
+1. Remove label (`tag.slash` icon) — removes the current label from selected emails.
+2. Move (`folder` icon) — opens the folder picker to move selected emails to another label.
+
+When viewing INBOX, only the Move button is shown. There is no equivalent "remove from inbox" action, even though Gmail's archive operation is exactly that — removing the `INBOX` label from a message. Users currently have to move messages to another folder to get them out of the inbox.
+
+## Goal
+
+In INBOX selection mode, present two action buttons: **Archive** and **Move**. Archive removes the `INBOX` label from selected emails (Gmail's archive semantics). Move continues to behave as today.
+
+## Non-goals
+
+- No changes to label-view selection mode behavior.
+- No new API surface in `services/gmailApi.ts` — Gmail has no dedicated archive endpoint; archive *is* `removeLabelIds: ['INBOX']`, which the existing `removeLabelFromEmails` handles.
+- No changes to the email detail screen.
+- No changes to selection-mode entry, multi-select, or the folder selection modal.
+
+## Design
+
+### Visibility
+
+Replace the existing `showRemoveLabel` derived value (currently `InboxScreen.tsx:353-356`) with a single predicate that is true when the source folder is INBOX **or** a user label (i.e., not a Gmail system pseudo-label):
+
+```ts
+const sourceFolderId = currentFolder?.id ?? 'INBOX';
+const isInbox = sourceFolderId === 'INBOX';
+const showRemoveOrArchive =
+  isInbox ||
+  (!sourceFolderId.startsWith('CATEGORY_') &&
+   !['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD'].includes(sourceFolderId));
+```
+
+This keeps the same exclusions for system labels and adds INBOX as a valid source.
+
+### Button render
+
+In the selection-mode header (`InboxScreen.tsx:468-472`), when `showRemoveOrArchive` is true, render one icon button whose icon and accessibility label depend on `isInbox`:
+
+- **INBOX:** icon `archivebox`, `accessibilityLabel="Archive"`.
+- **User label:** icon `tag.slash`, `accessibilityLabel="Remove label"` (today's behavior).
+
+Position: unchanged — left of the Move (folder) button. So in INBOX the layout becomes `[Archive] [Move]`; in a label view it stays `[Remove label] [Move]`.
+
+### Action handler
+
+`handleRemoveLabelBatch` (`InboxScreen.tsx:212-266`) currently early-returns when `currentFolder` is null. Change two things:
+
+1. Replace `if (!currentFolder) return;` with `const sourceFolderId = currentFolder?.id ?? 'INBOX';` and proceed.
+2. Branch the toast wording: when `sourceFolderId === 'INBOX'`, the success toast reads `${count} email(s) archived`; otherwise the existing `${count} email(s) removed`.
+
+Everything else in the function — the call to `removeLabelFromEmails(ids, sourceFolderId, ...)`, the failure-path `BatchErrorModal` with `action: 'remove'`, the Undo handler that calls `addLabelsToEmails(ids, [sourceFolderId])`, the `clearSelection` + `handleRefresh` calls — stays as-is. Adding INBOX back via `addLabelsToEmails` is the correct unarchive operation.
+
+### Error handling
+
+The existing `BatchErrorModal` flow handles partial failures unchanged. `batchErrorDetails.action: 'remove'` still applies semantically — archive is a remove-label internally, and the retry path (`handleRetryBatch`) calls `handleRemoveLabelBatch(failedIds)`, which now works for INBOX.
+
+## Out of scope / future considerations
+
+- A confirmation prompt before archiving. Not needed: undo is already provided via the toast.
+- Bulk-archive of all inbox emails (no selection). Not in scope.
+- An "archive" action on the email detail screen. Not in scope; this spec only covers selection-mode.
+
+## Testing
+
+Manual verification:
+
+1. In INBOX, long-press an email to enter selection mode. Confirm two icon buttons render: archive then folder.
+2. Tap archive. Confirm:
+   - Selected emails disappear from the inbox list.
+   - Toast reads "N email(s) archived" with an Undo action.
+   - Undo restores the emails to the inbox list.
+3. In a user label view, repeat selection mode. Confirm the layout still shows `tag.slash` then folder, and the existing remove-label flow is unchanged.
+4. In a system label view (e.g., STARRED, SENT), confirm only the Move button renders (no archive/remove-label button).
+5. Trigger a partial-failure batch (e.g., disconnect mid-action). Confirm `BatchErrorModal` appears and Retry re-runs the archive on failed IDs only.
+
+## Files touched
+
+- `components/InboxScreen.tsx` — visibility predicate, button render, handler tweak.
+
+No other files modified.

--- a/utils/folder-actions.test.ts
+++ b/utils/folder-actions.test.ts
@@ -1,0 +1,26 @@
+import { getSelectionAction } from './folder-actions';
+
+describe('getSelectionAction', () => {
+  it('returns "archive" for INBOX', () => {
+    expect(getSelectionAction('INBOX')).toBe('archive');
+  });
+
+  it('returns "remove-label" for a user label id', () => {
+    expect(getSelectionAction('Label_123')).toBe('remove-label');
+    expect(getSelectionAction('Label_abc')).toBe('remove-label');
+  });
+
+  it('returns "none" for Gmail system pseudo-labels', () => {
+    for (const id of ['TRASH', 'SENT', 'DRAFTS', 'SPAM', 'STARRED', 'IMPORTANT', 'UNREAD']) {
+      expect(getSelectionAction(id)).toBe('none');
+    }
+  });
+
+  it('returns "none" for CATEGORY_* labels', () => {
+    expect(getSelectionAction('CATEGORY_PROMOTIONS')).toBe('none');
+    expect(getSelectionAction('CATEGORY_SOCIAL')).toBe('none');
+    expect(getSelectionAction('CATEGORY_UPDATES')).toBe('none');
+    expect(getSelectionAction('CATEGORY_FORUMS')).toBe('none');
+    expect(getSelectionAction('CATEGORY_PERSONAL')).toBe('none');
+  });
+});

--- a/utils/folder-actions.ts
+++ b/utils/folder-actions.ts
@@ -1,0 +1,18 @@
+export type SelectionAction = 'archive' | 'remove-label' | 'none';
+
+const SYSTEM_LABEL_IDS = new Set([
+  'TRASH',
+  'SENT',
+  'DRAFTS',
+  'SPAM',
+  'STARRED',
+  'IMPORTANT',
+  'UNREAD',
+]);
+
+export function getSelectionAction(folderId: string): SelectionAction {
+  if (folderId === 'INBOX') return 'archive';
+  if (folderId.startsWith('CATEGORY_')) return 'none';
+  if (SYSTEM_LABEL_IDS.has(folderId)) return 'none';
+  return 'remove-label';
+}


### PR DESCRIPTION
## Summary

Adds an Archive button when the source folder is INBOX, in two places that previously offered no one-tap "remove from inbox" action:

- **Selection mode** in `components/InboxScreen.tsx` — header now shows `[Archive][Move]` when in INBOX, `[Remove label][Move]` in a user label, `[Move]` only in system folders.
- **Email detail** in `app/email/[id].tsx` — header gains an Archive button when the email was opened from INBOX, mirroring the same icon set.

Archive is implemented as Gmail's native `removeLabelIds: ['INBOX']` via the existing `removeLabelFromEmails`. Undo re-adds the INBOX label.

A new utility `utils/folder-actions.ts` (`getSelectionAction(folderId)` → `'archive' | 'remove-label' | 'none'`) encodes the system-label exclusions in one place and is unit-tested. Both surfaces consume it.

Move button accessibility label aligned to `"Move to folder"` across both surfaces.

Specs and plans live under `docs/superpowers/specs/` and `docs/superpowers/plans/` for traceability.

## Test Plan

Automated:
- [x] `npm test` — 60/60 pass (includes 4 new cases for `getSelectionAction`)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (11 pre-existing warnings)

Manual (please verify on device/simulator):
- [ ] INBOX selection mode: long-press → tap archive → toast "N email(s) archived" → Undo restores
- [ ] User-label selection mode: tag.slash icon and "removed" wording unchanged
- [ ] System-label view (STARRED/SENT): only Move button renders
- [ ] INBOX email detail: tap archive → returns to inbox, toast "1 email archived" → Undo restores
- [ ] User-label email detail: tag.slash icon and "1 email removed" wording unchanged
- [ ] Move flow still works in INBOX (both surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)