### PR TITLE
Add "Open in Gmail" button to email and folder screens

### DIFF
--- a/app/email/[id].tsx
+++ b/app/email/[id].tsx
@@ -27,6 +27,7 @@ import { useActionButtonColors } from '@/hooks/use-tint-contrast';
 import { getSelectionAction } from '@/utils/folder-actions';
 import { splitTextOnUrls, URL_PATTERN_SOURCE } from '@/utils/auto-link-urls';
 import { emailLoadErrorMessage } from '@/utils/email-load-error';
+import { getGmailMessageUrl } from '@/utils/gmail-web-links';
 
 const EmailDetailScreen = () => {
   const { id, folderId } = useLocalSearchParams<{ id: string; folderId?: string }>();
@@ -175,6 +176,11 @@ const EmailDetailScreen = () => {
     () => getSelectionAction(folderId ?? 'INBOX'),
     [folderId]
   );
+
+  const handleOpenInGmail = () => {
+    if (!email) return;
+    Linking.openURL(getGmailMessageUrl(email.threadId));
+  };
 
   const folderName = useMemo(() => {
     if (!folderId) return '';
@@ -517,6 +523,14 @@ const EmailDetailScreen = () => {
                 {...{ title: "Move to folder" } as any}
               >
                 <IconSymbol name="folder" size={isLargeScreen ? 28 : 22} color={textColor} />
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={handleOpenInGmail}
+                style={[styles.actionButton, styles.actionHitSlop]}
+                accessibilityLabel="Open in Gmail"
+                {...{ title: "Open in Gmail" } as any}
+              >
+                <IconSymbol name="arrow.up.right.square" size={isLargeScreen ? 28 : 22} color={textColor} />
               </TouchableOpacity>
             </>
           )}

--- a/app/folder/[id].tsx
+++ b/app/folder/[id].tsx
@@ -7,6 +7,7 @@ import {
   RefreshControl,
   Alert,
   ActivityIndicator,
+  Linking,
 } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { ThemedText } from '@/components/themed-text';
@@ -17,6 +18,7 @@ import { IconSymbol } from '@/components/ui/icon-symbol';
 import { EmailItem } from '@/components/EmailItem';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActionButtonColors } from '@/hooks/use-tint-contrast';
+import { getGmailFolderUrl } from '@/utils/gmail-web-links';
 
 const FolderScreen = () => {
   const { id, name } = useLocalSearchParams<{ id: string; name: string }>();
@@ -62,6 +64,11 @@ const FolderScreen = () => {
     setRefreshing(false);
   };
 
+  const handleOpenInGmail = () => {
+    if (!id) return;
+    Linking.openURL(getGmailFolderUrl(id, name ? decodeURIComponent(name) : undefined));
+  };
+
   const handleEmailPress = (email: any) => {
     // Navigate to email detail screen
     router.push(`/email/${email.id}?subject=${encodeURIComponent(email.subject)}&folderId=${id}`);
@@ -83,7 +90,14 @@ const FolderScreen = () => {
         <ThemedText type="title" style={styles.headerTitle}>
           {decodeURIComponent(name || 'Folder')}
         </ThemedText>
-        <View style={styles.placeholder} /> {/* Placeholder for alignment */}
+        <TouchableOpacity
+          onPress={handleOpenInGmail}
+          style={styles.openInGmailButton}
+          accessibilityLabel="Open in Gmail"
+          {...{ title: "Open in Gmail" } as any}
+        >
+          <IconSymbol name="arrow.up.right.square" size={22} color={textColor} />
+        </TouchableOpacity>
       </ThemedView>
 
       {error ? (
@@ -159,8 +173,11 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 18,
   },
-  placeholder: {
-    width: 40, // Same width as backButton for alignment
+  openInGmailButton: {
+    padding: 8,
+    marginLeft: 8,
+    minWidth: 40,
+    alignItems: 'center',
   },
   errorContainer: {
     flex: 1,

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -39,6 +39,7 @@ const MAPPING = {
   'exclamationmark.triangle': 'warning',
   'info.circle': 'info',
   'xmark.circle.fill': 'cancel',
+  'arrow.up.right.square': 'open-in-new',
 } as IconMapping;
 
 /**

--- a/utils/gmail-web-links.test.ts
+++ b/utils/gmail-web-links.test.ts
@@ -6,6 +6,12 @@ describe('getGmailMessageUrl', () => {
       'https://mail.google.com/mail/u/0/#all/18d2f3a4b5c6'
     );
   });
+
+  it('url-encodes the thread id', () => {
+    expect(getGmailMessageUrl('abc/def')).toBe(
+      'https://mail.google.com/mail/u/0/#all/abc%2Fdef'
+    );
+  });
 });
 
 describe('getGmailFolderUrl', () => {

--- a/utils/gmail-web-links.test.ts
+++ b/utils/gmail-web-links.test.ts
@@ -1,0 +1,38 @@
+import { getGmailMessageUrl, getGmailFolderUrl } from './gmail-web-links';
+
+describe('getGmailMessageUrl', () => {
+  it('builds an all-mail permalink from the thread id', () => {
+    expect(getGmailMessageUrl('18d2f3a4b5c6')).toBe(
+      'https://mail.google.com/mail/u/0/#all/18d2f3a4b5c6'
+    );
+  });
+});
+
+describe('getGmailFolderUrl', () => {
+  it('maps system labels to their Gmail anchors', () => {
+    expect(getGmailFolderUrl('INBOX')).toBe('https://mail.google.com/mail/u/0/#inbox');
+    expect(getGmailFolderUrl('SENT')).toBe('https://mail.google.com/mail/u/0/#sent');
+    expect(getGmailFolderUrl('DRAFT')).toBe('https://mail.google.com/mail/u/0/#drafts');
+    expect(getGmailFolderUrl('TRASH')).toBe('https://mail.google.com/mail/u/0/#trash');
+    expect(getGmailFolderUrl('SPAM')).toBe('https://mail.google.com/mail/u/0/#spam');
+    expect(getGmailFolderUrl('STARRED')).toBe('https://mail.google.com/mail/u/0/#starred');
+  });
+
+  it('builds a label permalink for user labels using the folder name', () => {
+    expect(getGmailFolderUrl('Label_123', 'Receipts')).toBe(
+      'https://mail.google.com/mail/u/0/#label/Receipts'
+    );
+  });
+
+  it('url-encodes label names with special characters', () => {
+    expect(getGmailFolderUrl('Label_456', 'Work/Projects')).toBe(
+      'https://mail.google.com/mail/u/0/#label/Work%2FProjects'
+    );
+  });
+
+  it('falls back to the folder id when no name is given for a user label', () => {
+    expect(getGmailFolderUrl('Label_789')).toBe(
+      'https://mail.google.com/mail/u/0/#label/Label_789'
+    );
+  });
+});

--- a/utils/gmail-web-links.ts
+++ b/utils/gmail-web-links.ts
@@ -12,7 +12,7 @@ const SYSTEM_LABEL_ANCHORS: Record<string, string> = {
 // Opens the message's thread in Gmail's "All Mail" view, which works
 // regardless of which folder/label the thread currently lives in.
 export function getGmailMessageUrl(threadId: string): string {
-  return `https://mail.google.com/mail/u/0/#all/${threadId}`;
+  return `https://mail.google.com/mail/u/0/#all/${encodeURIComponent(threadId)}`;
 }
 
 export function getGmailFolderUrl(folderId: string, folderName?: string): string {

--- a/utils/gmail-web-links.ts
+++ b/utils/gmail-web-links.ts
@@ -1,0 +1,24 @@
+const SYSTEM_LABEL_ANCHORS: Record<string, string> = {
+  INBOX: 'inbox',
+  SENT: 'sent',
+  DRAFT: 'drafts',
+  TRASH: 'trash',
+  SPAM: 'spam',
+  STARRED: 'starred',
+  IMPORTANT: 'imp',
+  CHAT: 'chats',
+};
+
+// Opens the message's thread in Gmail's "All Mail" view, which works
+// regardless of which folder/label the thread currently lives in.
+export function getGmailMessageUrl(threadId: string): string {
+  return `https://mail.google.com/mail/u/0/#all/${threadId}`;
+}
+
+export function getGmailFolderUrl(folderId: string, folderName?: string): string {
+  const anchor = SYSTEM_LABEL_ANCHORS[folderId];
+  if (anchor) {
+    return `https://mail.google.com/mail/u/0/#${anchor}`;
+  }
+  return `https://mail.google.com/mail/u/0/#label/${encodeURIComponent(folderName || folderId)}`;
+}


### PR DESCRIPTION
## Summary
- Add an "Open in Gmail" header action on the email detail screen (`app/email/[id].tsx`) that opens the current thread in Gmail's web UI (`https://mail.google.com/mail/u/0/#all/<threadId>`, which resolves regardless of which folder the thread is in)
- Add a matching "Open in Gmail" header action on the folder screen (`app/folder/[id].tsx`) that opens the corresponding Gmail label/inbox view, mapping known system labels (Inbox, Sent, Drafts, Trash, Spam, Starred) to their Gmail anchors and falling back to `#label/<name>` for user labels
- New `utils/gmail-web-links.ts` helper (`getGmailMessageUrl`, `getGmailFolderUrl`) with unit tests, plus a new `arrow.up.right.square` icon mapping

Closes #19

## Test plan
- [x] `npm test` — all 84 tests pass, including new `utils/gmail-web-links.test.ts`
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx expo lint` — no new warnings/errors introduced
- [ ] Manual check: tap "Open in Gmail" on an email and on a folder to confirm it opens the right thread/label in the Gmail app or browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01KWv2QrZk8FwEziLDLzkbhx)_