### PR TITLE
Fix emails not scrolling all the way to the bottom

### DIFF
--- a/app/email/[id].tsx
+++ b/app/email/[id].tsx
@@ -27,6 +27,7 @@ import { useActionButtonColors } from '@/hooks/use-tint-contrast';
 import { getSelectionAction } from '@/utils/folder-actions';
 import { splitTextOnUrls, URL_PATTERN_SOURCE } from '@/utils/auto-link-urls';
 import { emailLoadErrorMessage } from '@/utils/email-load-error';
+import { getEmailWebViewInjectedJavaScript } from '@/utils/email-webview-script';
 
 const EmailDetailScreen = () => {
   const { id, folderId } = useLocalSearchParams<{ id: string; folderId?: string }>();
@@ -586,24 +587,7 @@ const EmailDetailScreen = () => {
                   source={{ html: htmlContent || '' }}
                   style={{ height: webViewHeight, backgroundColor: 'transparent' }}
                   scrollEnabled={false}
-                  injectedJavaScript={`
-                    (function() {
-                      function reportHeight() {
-                        var h = document.documentElement.scrollHeight;
-                        var w = document.documentElement.scrollWidth;
-                        if (h > 0) window.ReactNativeWebView.postMessage(String(h));
-                        if (w > window.innerWidth) {
-                          document.body.style.overflowX = 'hidden';
-                          document.body.style.width = window.innerWidth + 'px';
-                        }
-                      }
-                      reportHeight();
-                      setTimeout(reportHeight, 300);
-                      setTimeout(reportHeight, 1000);
-                      setTimeout(reportHeight, 2000);
-                    })();
-                    true;
-                  `}
+                  injectedJavaScript={getEmailWebViewInjectedJavaScript()}
                   onMessage={(event: any) => {
                     if (event.nativeEvent.data) {
                       setWebViewHeight(Number(event.nativeEvent.data));

--- a/utils/email-view-fix.test.ts
+++ b/utils/email-view-fix.test.ts
@@ -1,3 +1,5 @@
+import { getEmailWebViewInjectedJavaScript } from './email-webview-script';
+
 describe('Email View Scroll Fix', () => {
   const generateHtmlWithViewportFix = () => {
     return `
@@ -58,23 +60,7 @@ describe('Email View Scroll Fix', () => {
   });
 
   describe('JavaScript height reporting fix', () => {
-    const injectedJs = `
-      (function() {
-        function reportHeight() {
-          var h = document.documentElement.scrollHeight;
-          var w = document.documentElement.scrollWidth;
-          if (h > 0) window.ReactNativeWebView.postMessage(String(h));
-          if (w > window.innerWidth) {
-            document.body.style.overflowX = 'hidden';
-            document.body.style.width = window.innerWidth + 'px';
-          }
-        }
-        reportHeight();
-        setTimeout(reportHeight, 300);
-        setTimeout(reportHeight, 1000);
-        setTimeout(reportHeight, 2000);
-      })();
-    `;
+    const injectedJs = getEmailWebViewInjectedJavaScript();
 
     it('checks both height and width for overflow', () => {
       expect(injectedJs).toContain('scrollHeight');
@@ -88,7 +74,16 @@ describe('Email View Scroll Fix', () => {
 
     it('reports height multiple times for dynamic content', () => {
       const count = (injectedJs.match(/reportHeight/g) || []).length;
-      expect(count).toBe(5);
+      expect(count).toBeGreaterThanOrEqual(5);
+    });
+
+    it('keeps observing layout changes via ResizeObserver so slow-loading emails stay fully scrollable', () => {
+      expect(injectedJs).toContain('ResizeObserver');
+    });
+
+    it('re-reports height once images finish loading', () => {
+      expect(injectedJs).toContain('document.images');
+      expect(injectedJs).toContain("addEventListener('load'");
     });
   });
 });

--- a/utils/email-webview-script.test.ts
+++ b/utils/email-webview-script.test.ts
@@ -1,0 +1,15 @@
+import { getEmailWebViewInjectedJavaScript } from './email-webview-script';
+
+describe('getEmailWebViewInjectedJavaScript', () => {
+  it('ends with `true;` as required by react-native-webview injectedJavaScript', () => {
+    expect(getEmailWebViewInjectedJavaScript().trim().endsWith('true;')).toBe(true);
+  });
+
+  it('only posts a height update when the height actually changes', () => {
+    expect(getEmailWebViewInjectedJavaScript()).toContain('h !== lastHeight');
+  });
+
+  it('schedules a longer-delay fallback report for slow-loading content', () => {
+    expect(getEmailWebViewInjectedJavaScript()).toContain('setTimeout(reportHeight, 4000)');
+  });
+});

--- a/utils/email-webview-script.test.ts
+++ b/utils/email-webview-script.test.ts
@@ -12,4 +12,8 @@ describe('getEmailWebViewInjectedJavaScript', () => {
   it('schedules a longer-delay fallback report for slow-loading content', () => {
     expect(getEmailWebViewInjectedJavaScript()).toContain('setTimeout(reportHeight, 4000)');
   });
+
+  it('disconnects the ResizeObserver on unload to avoid leaking it', () => {
+    expect(getEmailWebViewInjectedJavaScript()).toContain('ro.disconnect()');
+  });
 });

--- a/utils/email-webview-script.ts
+++ b/utils/email-webview-script.ts
@@ -35,6 +35,7 @@ export function getEmailWebViewInjectedJavaScript(): string {
       if (typeof ResizeObserver !== 'undefined') {
         var ro = new ResizeObserver(reportHeight);
         ro.observe(document.documentElement);
+        window.addEventListener('unload', function () { ro.disconnect(); });
       }
     })();
     true;

--- a/utils/email-webview-script.ts
+++ b/utils/email-webview-script.ts
@@ -1,0 +1,42 @@
+// Injected into the native WebView that renders an email's HTML body.
+// Reports content height back to React Native so the surrounding
+// ScrollView can be sized to fit the whole email. Height is re-reported
+// as async content (images, fonts, late reflows) settles, so long or
+// slow-loading emails don't get clipped before the user can scroll to
+// the bottom.
+export function getEmailWebViewInjectedJavaScript(): string {
+  return `
+    (function() {
+      var lastHeight = 0;
+      function reportHeight() {
+        var h = document.documentElement.scrollHeight;
+        var w = document.documentElement.scrollWidth;
+        if (h > 0 && h !== lastHeight) {
+          lastHeight = h;
+          window.ReactNativeWebView.postMessage(String(h));
+        }
+        if (w > window.innerWidth) {
+          document.body.style.overflowX = 'hidden';
+          document.body.style.width = window.innerWidth + 'px';
+        }
+      }
+      reportHeight();
+      setTimeout(reportHeight, 300);
+      setTimeout(reportHeight, 1000);
+      setTimeout(reportHeight, 2000);
+      setTimeout(reportHeight, 4000);
+      window.addEventListener('load', reportHeight);
+      Array.prototype.forEach.call(document.images, function (img) {
+        if (!img.complete) {
+          img.addEventListener('load', reportHeight);
+          img.addEventListener('error', reportHeight);
+        }
+      });
+      if (typeof ResizeObserver !== 'undefined') {
+        var ro = new ResizeObserver(reportHeight);
+        ro.observe(document.documentElement);
+      }
+    })();
+    true;
+  `;
+}


### PR DESCRIPTION
## Summary
- The native (iOS/Android) email view renders the HTML body in a `WebView` with `scrollEnabled={false}`, relying on injected JS to report `scrollHeight` back so the surrounding `ScrollView` can be sized to fit the content. That script only reported height at a few fixed timeouts (0/300/1000/2000ms), unlike the web `<iframe>` path which already used a `ResizeObserver` for this.
- For emails with large or slow-loading images (or content that reflows after ~2s), the last height report went stale before the content finished rendering. Since the `WebView` can't scroll internally either, the tail of the email became permanently unreachable — matching the reported "some emails can't scroll all the way to the bottom".
- Extracted the injected script into `utils/email-webview-script.ts` (`getEmailWebViewInjectedJavaScript`) and had it keep reporting height via a `ResizeObserver`, `load`/`error` listeners on any not-yet-loaded images, and a longer (4s) fallback timeout, deduping repeated height values to avoid extra re-renders.
- `utils/email-view-fix.test.ts` was previously testing a hardcoded copy of the injected script rather than the real implementation — rewired it (and added `utils/email-webview-script.test.ts`) to exercise the actual code.

Closes #22

## Test plan
- [x] `npm test` — all 84 tests pass, including the updated/new tests for the injected script
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx expo lint` — no new warnings/errors introduced
- [ ] Manual check on a device: open an email with large/slow-loading images (or one known to previously not scroll to the bottom) and confirm the full content is now reachable


---
_Generated by [Claude Code](https://claude.ai/code/session_01KWv2QrZk8FwEziLDLzkbhx)_