### PR TITLE
Add inbox filtering by label or search string

### DIFF
--- a/components/FolderSelectionModal.tsx
+++ b/components/FolderSelectionModal.tsx
@@ -24,6 +24,8 @@ interface FolderSelectionModalProps {
   onClose: () => void;
   onSelectFolder: (folder: GmailLabel) => void;
   currentFolderId?: string;
+  title?: string;
+  recordRecent?: boolean;
 }
 
 const MIN_COLUMN_WIDTH = 240;
@@ -34,6 +36,8 @@ const FolderSelectionModal: React.FC<FolderSelectionModalProps> = ({
   onClose,
   onSelectFolder,
   currentFolderId,
+  title = 'Select Folder',
+  recordRecent = true,
 }) => {
   const { folders, recentFolders, loading, error, loadFolders, addToRecentFolders } = useFolders();
   const [searchQuery, setSearchQuery] = useState('');
@@ -85,7 +89,9 @@ const FolderSelectionModal: React.FC<FolderSelectionModalProps> = ({
   ), [filteredFolders, folders, recentFolders, searchQuery, columnCount]);
 
   const handleSelectFolder = (folder: GmailLabel) => {
-    addToRecentFolders(folder);
+    if (recordRecent) {
+      addToRecentFolders(folder);
+    }
     onSelectFolder(folder);
     onClose();
   };
@@ -146,7 +152,7 @@ const FolderSelectionModal: React.FC<FolderSelectionModalProps> = ({
       <Pressable style={styles.overlay} onPress={onClose}>
         <Pressable style={[styles.modalContainer, { backgroundColor }]} onPress={() => {}}>
           <ThemedView style={[styles.header, { borderBottomColor: separatorColor }]}>
-            <ThemedText type="title" style={styles.title}>Select Folder</ThemedText>
+            <ThemedText type="title" style={styles.title}>{title}</ThemedText>
             <TouchableOpacity onPress={onClose} style={styles.closeButton}>
               <IconSymbol name="xmark" size={24} color={textColor} />
             </TouchableOpacity>

--- a/components/FolderSelectionModal.tsx
+++ b/components/FolderSelectionModal.tsx
@@ -25,7 +25,6 @@ interface FolderSelectionModalProps {
   onSelectFolder: (folder: GmailLabel) => void;
   currentFolderId?: string;
   title?: string;
-  recordRecent?: boolean;
 }
 
 const MIN_COLUMN_WIDTH = 240;
@@ -37,7 +36,6 @@ const FolderSelectionModal: React.FC<FolderSelectionModalProps> = ({
   onSelectFolder,
   currentFolderId,
   title = 'Select Folder',
-  recordRecent = true,
 }) => {
   const { folders, recentFolders, loading, error, loadFolders, addToRecentFolders } = useFolders();
   const [searchQuery, setSearchQuery] = useState('');
@@ -89,9 +87,7 @@ const FolderSelectionModal: React.FC<FolderSelectionModalProps> = ({
   ), [filteredFolders, folders, recentFolders, searchQuery, columnCount]);
 
   const handleSelectFolder = (folder: GmailLabel) => {
-    if (recordRecent) {
-      addToRecentFolders(folder);
-    }
+    addToRecentFolders(folder);
     onSelectFolder(folder);
     onClose();
   };

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -266,9 +266,14 @@ export function InboxScreen() {
           }
         );
       }
-      
+
+      const succeededIds = new Set(result.succeeded);
+      setEmailState(prev => ({
+        ...prev,
+        emails: prev.emails.filter(e => !succeededIds.has(e.id)),
+      }));
       clearSelection();
-      handleRefresh();
+      loadLabels();
 
     } catch (error: any) {
       console.error('Error removing labels:', error);
@@ -277,7 +282,7 @@ export function InboxScreen() {
       setActionLoading(false);
       setBatchProgress(null);
     }
-  }, [selectedIds, currentFolder, removeLabelFromEmails, addLabelsToEmails, moveEmailsToLabel, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
+  }, [selectedIds, currentFolder, removeLabelFromEmails, addLabelsToEmails, moveEmailsToLabel, clearSelection, loadLabels, showToast, showUndoToast, emailState.emails]);
 
   const handleMoveToFolder = useCallback(async (targetLabelId: string, idsToProcess?: string[]) => {
     setActionLoading(true);
@@ -323,9 +328,14 @@ export function InboxScreen() {
           }
         );
       }
-      
+
+      const succeededIds = new Set(result.succeeded);
+      setEmailState(prev => ({
+        ...prev,
+        emails: prev.emails.filter(e => !succeededIds.has(e.id)),
+      }));
       clearSelection();
-      handleRefresh();
+      loadLabels();
 
     } catch (error: any) {
       console.error('Error moving emails:', error);
@@ -334,7 +344,7 @@ export function InboxScreen() {
       setActionLoading(false);
       setBatchProgress(null);
     }
-  }, [selectedIds, moveEmailsToLabel, currentFolder, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
+  }, [selectedIds, moveEmailsToLabel, currentFolder, clearSelection, loadLabels, showToast, showUndoToast, emailState.emails]);
 
   const handleRetryBatch = () => {
     if (!batchErrorDetails) return;

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -30,7 +30,7 @@ import { useActionButtonColors } from '@/hooks/use-tint-contrast';
 
 import { useEmailSelection } from '@/hooks/useEmailSelection';
 import { getSelectionAction } from '@/utils/folder-actions';
-import { filterEmails, getEffectiveSourceLabelId } from '@/utils/email-filter';
+import { filterEmails } from '@/utils/email-filter';
 
 import { EmailItemSkeleton } from '@/components/EmailItemSkeleton';
 
@@ -92,10 +92,6 @@ export function InboxScreen() {
   const progressAnimation = useRef(new Animated.Value(0)).current;
 
   const userEmail = authState.status === 'authenticated' ? authState.userEmail : '';
-  // When a filter label is active, batch actions (remove/move) should
-  // operate on that label, not the folder the view is actually loaded
-  // from — see issue #21.
-  const effectiveLabelId = getEffectiveSourceLabelId(filterLabel?.id, currentFolder?.id);
   const visibleEmails = useMemo(
     () => filterEmails(emailState.emails, { labelId: filterLabel?.id, searchQuery }),
     [emailState.emails, filterLabel?.id, searchQuery]
@@ -194,9 +190,10 @@ export function InboxScreen() {
     if (isSelectionMode) {
       toggleSelection(email.id);
     } else {
-      router.push(`/email/${email.id}?subject=${encodeURIComponent(email.subject)}&folderId=${encodeURIComponent(effectiveLabelId)}`);
+      const folderId = currentFolder?.id || 'INBOX';
+      router.push(`/email/${email.id}?subject=${encodeURIComponent(email.subject)}&folderId=${encodeURIComponent(folderId)}`);
     }
-  }, [isSelectionMode, toggleSelection, effectiveLabelId]);
+  }, [isSelectionMode, toggleSelection, currentFolder]);
 
   const handleEmailLongPress = useCallback((email: Email) => {
     if (!isSelectionMode) {
@@ -227,7 +224,7 @@ export function InboxScreen() {
   const handleRemoveLabelBatch = useCallback(async (idsToProcess?: string[]) => {
     setActionLoading(true);
     const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
-    const sourceFolderId = effectiveLabelId;
+    const sourceFolderId = currentFolder?.id ?? 'INBOX';
     setBatchProgress({
       processed: 0,
       total: ids.length,
@@ -280,12 +277,12 @@ export function InboxScreen() {
       setActionLoading(false);
       setBatchProgress(null);
     }
-  }, [selectedIds, effectiveLabelId, removeLabelFromEmails, addLabelsToEmails, moveEmailsToLabel, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
+  }, [selectedIds, currentFolder, removeLabelFromEmails, addLabelsToEmails, moveEmailsToLabel, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
 
   const handleMoveToFolder = useCallback(async (targetLabelId: string, idsToProcess?: string[]) => {
     setActionLoading(true);
     const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
-    const sourceFolderId = effectiveLabelId;
+    const sourceFolderId = currentFolder?.id || 'INBOX';
     setBatchProgress({
       processed: 0,
       total: ids.length,
@@ -337,7 +334,7 @@ export function InboxScreen() {
       setActionLoading(false);
       setBatchProgress(null);
     }
-  }, [selectedIds, moveEmailsToLabel, effectiveLabelId, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
+  }, [selectedIds, moveEmailsToLabel, currentFolder, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
 
   const handleRetryBatch = () => {
     if (!batchErrorDetails) return;
@@ -379,7 +376,7 @@ export function InboxScreen() {
     setFilterLabel(null);
   }, []);
 
-  const selectionAction = getSelectionAction(effectiveLabelId);
+  const selectionAction = getSelectionAction(currentFolder?.id ?? 'INBOX');
 
   const renderEmail = useCallback(
     ({ item }: { item: Email }) => (

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -98,7 +98,7 @@ export function InboxScreen() {
   const effectiveLabelId = getEffectiveSourceLabelId(filterLabel?.id, currentFolder?.id);
   const visibleEmails = useMemo(
     () => filterEmails(emailState.emails, { labelId: filterLabel?.id, searchQuery }),
-    [emailState.emails, filterLabel, searchQuery]
+    [emailState.emails, filterLabel?.id, searchQuery]
   );
   const isFilterActive = !!filterLabel || searchQuery.trim().length > 0;
   const progressRatio =

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -92,9 +92,9 @@ export function InboxScreen() {
   const progressAnimation = useRef(new Animated.Value(0)).current;
 
   const userEmail = authState.status === 'authenticated' ? authState.userEmail : '';
-  // When a filter label is active, batch actions (remove/move) and the
-  // "current folder" chip should operate on that label, not the folder the
-  // view is actually loaded from — see issue #21.
+  // When a filter label is active, batch actions (remove/move) should
+  // operate on that label, not the folder the view is actually loaded
+  // from — see issue #21.
   const effectiveLabelId = getEffectiveSourceLabelId(filterLabel?.id, currentFolder?.id);
   const visibleEmails = useMemo(
     () => filterEmails(emailState.emails, { labelId: filterLabel?.id, searchQuery }),
@@ -391,10 +391,10 @@ export function InboxScreen() {
         isSelected={selectedIds.has(item.id)}
         isSelectionMode={isSelectionMode}
         labels={labelsMap}
-        currentFolderId={effectiveLabelId}
+        currentFolderId={currentFolder?.id || 'INBOX'}
       />
     ),
-    [handleEmailPress, handleEmailLongPress, toggleSelection, selectedIds, isSelectionMode, labelsMap, effectiveLabelId]
+    [handleEmailPress, handleEmailLongPress, toggleSelection, selectedIds, isSelectionMode, labelsMap, currentFolder]
   );
 
   const renderFooter = useCallback(() => {

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   View,
   Text,
@@ -8,6 +8,7 @@ import {
   RefreshControl,
   Pressable,
   TouchableOpacity,
+  TextInput,
   useWindowDimensions,
   Animated,
   Easing,
@@ -29,6 +30,7 @@ import { useActionButtonColors } from '@/hooks/use-tint-contrast';
 
 import { useEmailSelection } from '@/hooks/useEmailSelection';
 import { getSelectionAction } from '@/utils/folder-actions';
+import { filterEmails, getEffectiveSourceLabelId } from '@/utils/email-filter';
 
 import { EmailItemSkeleton } from '@/components/EmailItemSkeleton';
 
@@ -83,9 +85,22 @@ export function InboxScreen() {
   const [batchProgress, setBatchProgress] = useState<BatchProgress | null>(null);
   const [labelsMap, setLabelsMap] = useState<Record<string, GmailLabel>>({});
   const [showComposeModal, setShowComposeModal] = useState(false);
+  const [showFilterBar, setShowFilterBar] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterLabel, setFilterLabel] = useState<GmailLabel | null>(null);
+  const [showLabelFilterModal, setShowLabelFilterModal] = useState(false);
   const progressAnimation = useRef(new Animated.Value(0)).current;
 
   const userEmail = authState.status === 'authenticated' ? authState.userEmail : '';
+  // When a filter label is active, batch actions (remove/move) and the
+  // "current folder" chip should operate on that label, not the folder the
+  // view is actually loaded from — see issue #21.
+  const effectiveLabelId = getEffectiveSourceLabelId(filterLabel?.id, currentFolder?.id);
+  const visibleEmails = useMemo(
+    () => filterEmails(emailState.emails, { labelId: filterLabel?.id, searchQuery }),
+    [emailState.emails, filterLabel, searchQuery]
+  );
+  const isFilterActive = !!filterLabel || searchQuery.trim().length > 0;
   const progressRatio =
     actionLoading && batchProgress && batchProgress.total > 0
       ? batchProgress.processed / batchProgress.total
@@ -179,10 +194,9 @@ export function InboxScreen() {
     if (isSelectionMode) {
       toggleSelection(email.id);
     } else {
-      const folderId = currentFolder?.id || 'INBOX';
-      router.push(`/email/${email.id}?subject=${encodeURIComponent(email.subject)}&folderId=${encodeURIComponent(folderId)}`);
+      router.push(`/email/${email.id}?subject=${encodeURIComponent(email.subject)}&folderId=${encodeURIComponent(effectiveLabelId)}`);
     }
-  }, [isSelectionMode, toggleSelection, currentFolder]);
+  }, [isSelectionMode, toggleSelection, effectiveLabelId]);
 
   const handleEmailLongPress = useCallback((email: Email) => {
     if (!isSelectionMode) {
@@ -201,19 +215,19 @@ export function InboxScreen() {
   }, [handleRefresh]);
 
   const handleSelectAll = useCallback(() => {
-    const allIds = emailState.emails.map(e => e.id);
-    const allSelected = selectedIds.size === emailState.emails.length && emailState.emails.length > 0;
+    const allIds = visibleEmails.map(e => e.id);
+    const allSelected = selectedIds.size === visibleEmails.length && visibleEmails.length > 0;
     if (allSelected) {
       clearSelection();
     } else {
       selectAll(allIds);
     }
-  }, [emailState.emails, selectedIds.size, selectAll, clearSelection]);
+  }, [visibleEmails, selectedIds.size, selectAll, clearSelection]);
 
   const handleRemoveLabelBatch = useCallback(async (idsToProcess?: string[]) => {
     setActionLoading(true);
     const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
-    const sourceFolderId = currentFolder?.id ?? 'INBOX';
+    const sourceFolderId = effectiveLabelId;
     setBatchProgress({
       processed: 0,
       total: ids.length,
@@ -266,12 +280,12 @@ export function InboxScreen() {
       setActionLoading(false);
       setBatchProgress(null);
     }
-  }, [selectedIds, currentFolder, removeLabelFromEmails, addLabelsToEmails, moveEmailsToLabel, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
+  }, [selectedIds, effectiveLabelId, removeLabelFromEmails, addLabelsToEmails, moveEmailsToLabel, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
 
   const handleMoveToFolder = useCallback(async (targetLabelId: string, idsToProcess?: string[]) => {
     setActionLoading(true);
     const ids = Array.isArray(idsToProcess) ? idsToProcess : Array.from(selectedIds);
-    const sourceFolderId = currentFolder?.id || 'INBOX';
+    const sourceFolderId = effectiveLabelId;
     setBatchProgress({
       processed: 0,
       total: ids.length,
@@ -323,7 +337,7 @@ export function InboxScreen() {
       setActionLoading(false);
       setBatchProgress(null);
     }
-  }, [selectedIds, moveEmailsToLabel, currentFolder, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
+  }, [selectedIds, moveEmailsToLabel, effectiveLabelId, clearSelection, handleRefresh, showToast, showUndoToast, emailState.emails]);
 
   const handleRetryBatch = () => {
     if (!batchErrorDetails) return;
@@ -349,11 +363,23 @@ export function InboxScreen() {
       setShowFolderModal(false);
     } else {
       setCurrentFolder(folder);
+      setFilterLabel(null);
+      setSearchQuery('');
+      setShowFilterBar(false);
       loadEmails(folder.id);
     }
   }, [isSelectionMode, loadEmails, handleMoveToFolder]);
 
-  const selectionAction = getSelectionAction(currentFolder?.id ?? 'INBOX');
+  const handleSelectFilterLabel = useCallback((label: GmailLabel) => {
+    setFilterLabel(label);
+    setShowLabelFilterModal(false);
+  }, []);
+
+  const handleClearFilterLabel = useCallback(() => {
+    setFilterLabel(null);
+  }, []);
+
+  const selectionAction = getSelectionAction(effectiveLabelId);
 
   const renderEmail = useCallback(
     ({ item }: { item: Email }) => (
@@ -365,10 +391,10 @@ export function InboxScreen() {
         isSelected={selectedIds.has(item.id)}
         isSelectionMode={isSelectionMode}
         labels={labelsMap}
-        currentFolderId={currentFolder?.id || 'INBOX'}
+        currentFolderId={effectiveLabelId}
       />
     ),
-    [handleEmailPress, handleEmailLongPress, toggleSelection, selectedIds, isSelectionMode, labelsMap, currentFolder]
+    [handleEmailPress, handleEmailLongPress, toggleSelection, selectedIds, isSelectionMode, labelsMap, effectiveLabelId]
   );
 
   const renderFooter = useCallback(() => {
@@ -393,6 +419,17 @@ export function InboxScreen() {
   const renderEmpty = useCallback(() => {
     if (emailState.isLoading) return null;
 
+    if (isFilterActive && emailState.emails.length > 0) {
+      return (
+        <View style={styles.emptyContainer}>
+          <IconSymbol name="magnifyingglass" size={64} color={textColor + '40'} />
+          <Text style={[styles.emptyText, { color: textColor + '80' }]}>
+            No emails match your filter
+          </Text>
+        </View>
+      );
+    }
+
     return (
       <View style={styles.emptyContainer}>
         <IconSymbol name="tray.fill" size={64} color={textColor + '40'} />
@@ -401,7 +438,7 @@ export function InboxScreen() {
         </Text>
       </View>
     );
-  }, [emailState.isLoading, currentFolder, textColor]);
+  }, [emailState.isLoading, emailState.emails.length, isFilterActive, currentFolder, textColor]);
 
   if (emailState.isLoading && emailState.emails.length === 0) {
     return (
@@ -432,6 +469,14 @@ export function InboxScreen() {
         onClose={() => setShowFolderModal(false)}
         onSelectFolder={handleSelectFolder}
         currentFolderId={currentFolder?.id}
+      />
+      <FolderSelectionModal
+        visible={showLabelFilterModal}
+        onClose={() => setShowLabelFilterModal(false)}
+        onSelectFolder={handleSelectFilterLabel}
+        currentFolderId={filterLabel?.id}
+        title="Filter by Label"
+        recordRecent={false}
       />
       <ComposeEmailModal
         visible={showComposeModal}
@@ -498,7 +543,7 @@ export function InboxScreen() {
             <Pressable onPress={handleSelectAll} style={styles.selectionBarButton}>
               <IconSymbol
                 name={
-                  selectedIds.size === emailState.emails.length && emailState.emails.length > 0
+                  selectedIds.size === visibleEmails.length && visibleEmails.length > 0
                     ? 'checkmark.circle'
                     : 'circle'
                 }
@@ -548,12 +593,66 @@ export function InboxScreen() {
               {userEmail}
             </Text>
           </View>
-          <Pressable
-            style={[styles.signOutButton, { borderColor: tintColor }]}
-            onPress={signOut}
+          <View style={styles.headerRight}>
+            <TouchableOpacity
+              onPress={() => setShowFilterBar(prev => !prev)}
+              style={styles.filterToggleButton}
+              accessibilityLabel="Filter emails"
+            >
+              <IconSymbol
+                name="magnifyingglass"
+                size={22}
+                color={showFilterBar || isFilterActive ? tintColor : textColor}
+              />
+            </TouchableOpacity>
+            <Pressable
+              style={[styles.signOutButton, { borderColor: tintColor }]}
+              onPress={signOut}
+            >
+              <Text style={[styles.signOutText, { color: tintColor }]}>Sign Out</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {!isSelectionMode && showFilterBar && (
+        <View style={[styles.filterBar, { borderBottomColor: textColor + '20' }]}>
+          <View style={[styles.searchInputContainer, { borderColor: textColor + '30' }]}>
+            <IconSymbol name="magnifyingglass" size={16} color={textColor + '80'} />
+            <TextInput
+              style={[styles.searchInput, { color: textColor }]}
+              placeholder="Search subject, sender, or snippet"
+              placeholderTextColor={textColor + '80'}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCorrect={false}
+            />
+            {searchQuery.length > 0 && (
+              <TouchableOpacity onPress={() => setSearchQuery('')} accessibilityLabel="Clear search">
+                <IconSymbol name="xmark.circle.fill" size={16} color={textColor + '60'} />
+              </TouchableOpacity>
+            )}
+          </View>
+          <TouchableOpacity
+            style={[
+              styles.labelFilterChip,
+              { borderColor: filterLabel ? tintColor : textColor + '30' },
+            ]}
+            onPress={() => setShowLabelFilterModal(true)}
           >
-            <Text style={[styles.signOutText, { color: tintColor }]}>Sign Out</Text>
-          </Pressable>
+            <IconSymbol name="tag" size={16} color={filterLabel ? tintColor : textColor + '80'} />
+            <Text
+              style={[styles.labelFilterText, { color: filterLabel ? tintColor : textColor + '80' }]}
+              numberOfLines={1}
+            >
+              {filterLabel ? filterLabel.name : 'Label'}
+            </Text>
+            {filterLabel && (
+              <Pressable onPress={handleClearFilterLabel} hitSlop={8} accessibilityLabel="Clear label filter">
+                <IconSymbol name="xmark" size={14} color={tintColor} />
+              </Pressable>
+            )}
+          </TouchableOpacity>
         </View>
       )}
 
@@ -583,7 +682,7 @@ export function InboxScreen() {
         </View>
       ) : (
         <FlatList
-          data={emailState.emails}
+          data={visibleEmails}
           renderItem={renderEmail}
           keyExtractor={(item) => item.id}
           refreshControl={
@@ -597,7 +696,7 @@ export function InboxScreen() {
           ListFooterComponent={renderFooter}
           onEndReached={loadMoreEmails}
           onEndReachedThreshold={0.5}
-          contentContainerStyle={emailState.emails.length === 0 ? styles.emptyList : undefined}
+          contentContainerStyle={visibleEmails.length === 0 ? styles.emptyList : undefined}
         />
       )}
       {!isSelectionMode && (
@@ -659,6 +758,55 @@ const styles = StyleSheet.create({
   headerActions: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  filterToggleButton: {
+    padding: 8,
+    minWidth: 40,
+    minHeight: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  filterBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    gap: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  searchInputContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 6,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+    padding: 0,
+  },
+  labelFilterChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    maxWidth: 130,
+    gap: 4,
+  },
+  labelFilterText: {
+    fontSize: 13,
+    fontWeight: '500',
+    flexShrink: 1,
   },
   selectionActionButton: {
     padding: 12,

--- a/components/InboxScreen.tsx
+++ b/components/InboxScreen.tsx
@@ -476,7 +476,6 @@ export function InboxScreen() {
         onSelectFolder={handleSelectFilterLabel}
         currentFolderId={filterLabel?.id}
         title="Filter by Label"
-        recordRecent={false}
       />
       <ComposeEmailModal
         visible={showComposeModal}

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -39,6 +39,7 @@ const MAPPING = {
   'exclamationmark.triangle': 'warning',
   'info.circle': 'info',
   'xmark.circle.fill': 'cancel',
+  'tag': 'label',
 } as IconMapping;
 
 /**

--- a/utils/email-filter.test.ts
+++ b/utils/email-filter.test.ts
@@ -1,4 +1,4 @@
-import { matchesEmailSearch, filterEmails, getEffectiveSourceLabelId, FilterableEmail } from './email-filter';
+import { matchesEmailSearch, filterEmails, FilterableEmail } from './email-filter';
 
 const makeEmail = (overrides: Partial<FilterableEmail> = {}): FilterableEmail => ({
   subject: 'Quarterly report',
@@ -60,21 +60,5 @@ describe('filterEmails', () => {
   it('excludes everything when the label filter matches nothing', () => {
     const result = filterEmails(emails, { labelId: 'Label_does_not_exist' });
     expect(result).toEqual([]);
-  });
-});
-
-describe('getEffectiveSourceLabelId', () => {
-  it('prefers the active filter label over the current folder', () => {
-    expect(getEffectiveSourceLabelId('Label_finance', 'INBOX')).toBe('Label_finance');
-  });
-
-  it('falls back to the current folder when no filter label is set', () => {
-    expect(getEffectiveSourceLabelId(null, 'Label_work')).toBe('Label_work');
-    expect(getEffectiveSourceLabelId(undefined, 'Label_work')).toBe('Label_work');
-  });
-
-  it('falls back to INBOX when neither is set', () => {
-    expect(getEffectiveSourceLabelId(null, null)).toBe('INBOX');
-    expect(getEffectiveSourceLabelId(undefined, undefined)).toBe('INBOX');
   });
 });

--- a/utils/email-filter.test.ts
+++ b/utils/email-filter.test.ts
@@ -1,0 +1,80 @@
+import { matchesEmailSearch, filterEmails, getEffectiveSourceLabelId, FilterableEmail } from './email-filter';
+
+const makeEmail = (overrides: Partial<FilterableEmail> = {}): FilterableEmail => ({
+  subject: 'Quarterly report',
+  from: 'Alice <alice@example.com>',
+  snippet: 'Please find attached the numbers',
+  labelIds: ['INBOX', 'Label_1'],
+  ...overrides,
+});
+
+describe('matchesEmailSearch', () => {
+  it('matches with an empty query', () => {
+    expect(matchesEmailSearch(makeEmail(), '')).toBe(true);
+    expect(matchesEmailSearch(makeEmail(), '   ')).toBe(true);
+  });
+
+  it('matches case-insensitively against the subject', () => {
+    expect(matchesEmailSearch(makeEmail(), 'QUARTERLY')).toBe(true);
+  });
+
+  it('matches against the sender', () => {
+    expect(matchesEmailSearch(makeEmail(), 'alice@example.com')).toBe(true);
+  });
+
+  it('matches against the snippet', () => {
+    expect(matchesEmailSearch(makeEmail(), 'attached')).toBe(true);
+  });
+
+  it('returns false when nothing matches', () => {
+    expect(matchesEmailSearch(makeEmail(), 'invoice')).toBe(false);
+  });
+});
+
+describe('filterEmails', () => {
+  const emails = [
+    makeEmail({ subject: 'Quarterly report', labelIds: ['INBOX', 'Label_finance'] }),
+    makeEmail({ subject: 'Team lunch', from: 'Bob <bob@example.com>', labelIds: ['INBOX', 'Label_social'] }),
+    makeEmail({ subject: 'Invoice #42', labelIds: ['INBOX'] }),
+  ];
+
+  it('returns all emails when no filters are set', () => {
+    expect(filterEmails(emails, {})).toHaveLength(3);
+  });
+
+  it('filters by label id', () => {
+    const result = filterEmails(emails, { labelId: 'Label_finance' });
+    expect(result).toEqual([emails[0]]);
+  });
+
+  it('filters by search query', () => {
+    const result = filterEmails(emails, { searchQuery: 'invoice' });
+    expect(result).toEqual([emails[2]]);
+  });
+
+  it('combines label and search filters with AND semantics', () => {
+    const result = filterEmails(emails, { labelId: 'INBOX', searchQuery: 'lunch' });
+    expect(result).toEqual([emails[1]]);
+  });
+
+  it('excludes everything when the label filter matches nothing', () => {
+    const result = filterEmails(emails, { labelId: 'Label_does_not_exist' });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getEffectiveSourceLabelId', () => {
+  it('prefers the active filter label over the current folder', () => {
+    expect(getEffectiveSourceLabelId('Label_finance', 'INBOX')).toBe('Label_finance');
+  });
+
+  it('falls back to the current folder when no filter label is set', () => {
+    expect(getEffectiveSourceLabelId(null, 'Label_work')).toBe('Label_work');
+    expect(getEffectiveSourceLabelId(undefined, 'Label_work')).toBe('Label_work');
+  });
+
+  it('falls back to INBOX when neither is set', () => {
+    expect(getEffectiveSourceLabelId(null, null)).toBe('INBOX');
+    expect(getEffectiveSourceLabelId(undefined, undefined)).toBe('INBOX');
+  });
+});

--- a/utils/email-filter.ts
+++ b/utils/email-filter.ts
@@ -1,0 +1,35 @@
+export interface FilterableEmail {
+  subject: string;
+  from: string;
+  snippet: string;
+  labelIds: string[];
+}
+
+// Case-insensitive match against subject/sender/snippet.
+export function matchesEmailSearch(email: FilterableEmail, searchQuery: string): boolean {
+  const normalized = searchQuery.trim().toLowerCase();
+  if (!normalized) return true;
+  const haystack = `${email.subject} ${email.from} ${email.snippet}`.toLowerCase();
+  return haystack.includes(normalized);
+}
+
+export function filterEmails<T extends FilterableEmail>(
+  emails: T[],
+  { labelId, searchQuery }: { labelId?: string | null; searchQuery?: string }
+): T[] {
+  return emails.filter(email => {
+    if (labelId && !email.labelIds.includes(labelId)) return false;
+    return matchesEmailSearch(email, searchQuery ?? '');
+  });
+}
+
+// When a view (e.g. Inbox) is additionally filtered by another label, actions
+// like "remove label" and "move" should operate on that filter label rather
+// than the view's underlying folder — otherwise they silently act on the
+// wrong label (see issue #21).
+export function getEffectiveSourceLabelId(
+  filterLabelId: string | null | undefined,
+  currentFolderId: string | null | undefined
+): string {
+  return filterLabelId || currentFolderId || 'INBOX';
+}

--- a/utils/email-filter.ts
+++ b/utils/email-filter.ts
@@ -22,14 +22,3 @@ export function filterEmails<T extends FilterableEmail>(
     return matchesEmailSearch(email, searchQuery ?? '');
   });
 }
-
-// When a view (e.g. Inbox) is additionally filtered by another label, actions
-// like "remove label" and "move" should operate on that filter label rather
-// than the view's underlying folder — otherwise they silently act on the
-// wrong label (see issue #21).
-export function getEffectiveSourceLabelId(
-  filterLabelId: string | null | undefined,
-  currentFolderId: string | null | undefined
-): string {
-  return filterLabelId || currentFolderId || 'INBOX';
-}


### PR DESCRIPTION
## Summary
- Adds a filter bar to the Inbox screen (`components/InboxScreen.tsx`), toggled by a new search icon in the header, with:
  - A free-text search box that matches subject, sender, and snippet (case-insensitive)
  - A secondary "label" filter (reusing `FolderSelectionModal` as a label picker) that narrows the view to emails also carrying that label
  - Both filters are applied client-side to the currently loaded page of emails; switching folders clears the filter
  - Picking a filter label also records it in "recent folders", same as folder browsing/moving
- Batch actions ("remove label" / "move") always operate on the real folder the view is loaded from (e.g. `INBOX`) — the filter label is display-only and is left untouched by these actions. This matches the behavior described in #21 once clarified: remove/move should act on the folder, not the filter.
- The active filter label's chip stays visible on list items (only the underlying folder's own label is suppressed as redundant, same as before this PR).
- Fixed a separate bug surfaced during testing: batch remove/move used to call a full list refresh afterward, which re-fetches only the first page (20) of the folder and replaces the whole list — silently dropping any untouched email that had only been reachable via pagination ("Load More"). Batch actions now just remove the successfully-processed ids from the local list instead of refetching, so nothing else in view disappears.
- Extracted the filtering logic into `utils/email-filter.ts` (`filterEmails`, `matchesEmailSearch`) with unit tests, since component logic in this repo isn't covered by the Jest config (`.test.ts` only)
- `FolderSelectionModal` gained an optional `title` prop so it can be reused as a generic label picker
- New `tag` icon mapping for the label-filter chip

Closes #21

## Test plan
- [x] `npm test` — all 101 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx expo lint` — no new warnings/errors introduced
- [x] Manually verified by the repo owner: filter bar toggle, search, label filter, chip visibility while filtering, and remove/move acting on the real folder while leaving the filter label and any paginated emails untouched.
